### PR TITLE
Adding option to use an Azure Backup Vault

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ backends:  # Configuration for the different backends. Required fields are only 
       vnets:  # List of vnets the storage account should allow access from. Each vnet listed here must have Microsoft.Storage added to the ServiceEndpoints collection of the subnet, optional
         - vnet: foobar-vnet  # Name of the virtual network, required
           subnet: default  # Name of the subnet, required
-    backup: # Configuration for use of Azure Backup Services
+    backup: # Configuration for use of Azure Backup Services. vault_name and policy_id are mandatory, if you want to use Azure Backup
       vault_name: foobar-vault  # The name of the existing backup vault, make sure the Storage Account has the Role Assignment "Storage Account Backup Contributor" for the according vault
       policy_id: 123123123  # The policy within the backup vault to use
     parameters:  # Fields here define defaults for parameters also in the CRD and are used if the parameter is not set in the custom object supplied by the user
@@ -129,6 +129,8 @@ To protect storage accounts against accidential deletion you can enable `lock_fr
 The azure backend also support a feature called `fake deletion` (via options `delete_fake`) where the storage accounts are not actually deleted but only tagged to mark it as deleted when the kubernetes custom object is deleted. This can be used in situations where the operator is freshly introduced in an environment where the users have little experience with this type of declarative management and you want to reduce the risk of accidental data loss.
 
 For the azureblob backend there are several ways to protect the storage accounts from external access. One is on the network layer by disabling network access to the accounts from outside the cluster (via the `parameters.network.public_access` and `parameters.network.firewall_rules` and `network.vnets`) and the other is on the access layer by disallowing anonymous access (via `allow_anonymous_access`, this only gives the users the right to configure anonymous access, unless a user specifically does that only authenticated access is possible).
+
+The azureblob backend supports backups using [Azure Backup Vaults](https://learn.microsoft.com/en-us/azure/backup/backup-vault-overview). To enable Azure backup, first set the two fields `backup.vault_name` (the existing backup vault to use) and `backup.policy_id` (the existing policy to use). Now you can either enable backups by default using the field `parameters.backup.enabled` or configure backup per manifest using the field `backup.enabled`. Note: the configuration in the manifest overrides the global operator configuration.
 
 For the operator to interact with Azure it needs credentials. For local testing it can pick up the token from the azure cli but for real deployments it needs a dedicated service principal. Supply the credentials for the service principal using the environment variables `AZURE_SUBSCRIPTION_ID`, `AZURE_TENANT_ID`, `AZURE_CLIENT_ID` and `AZURE_CLIENT_SECRET` (if you deploy via the helm chart use the use `envSecret` value). Depending on the backend the operator requires the following azure permissions within the scope of the resource group it deploys to:
 

--- a/README.md
+++ b/README.md
@@ -102,6 +102,10 @@ backends:  # Configuration for the different backends. Required fields are only 
       vnets:  # List of vnets the storage account should allow access from. Each vnet listed here must have Microsoft.Storage added to the ServiceEndpoints collection of the subnet, optional
         - vnet: foobar-vnet  # Name of the virtual network, required
           subnet: default  # Name of the subnet, required
+    backup: # Configuration for use of Azure Backup Services
+      enabled: false  # If enabled, the storage account will be added to an existing backup vault. Backup instances will not be cleaned up with Object Storage Buckets for recovery purposes
+      vault_name: foobar-vault  # The name of the existing backup vault, make sure the Storage Account has the Role Assignment "Storage Account Backup Contributor" for the according vault
+      policy_id: 123123123  # The policy within the backup vault to use
     parameters:  # Fields here define defaults for parameters also in the CRD and are used if the parameter is not set in the custom object supplied by the user
       network:
         public_access: false  # If set to true no network restrictions are placed on the storage account, if set to false access is only possible through vnet and firewall rules, optional
@@ -215,7 +219,7 @@ To run it locally follow these steps:
 1. Create and activate a local python virtualenv
 2. Install dependencies: `pip install -r requirements.txt`
 3. Setup a local kubernetes cluster, e.g. with k3d: `k3d cluster create`
-4. Apply the CRDs in your local cluster: `kubectl apply -f helm/hybrid-cloud-object-storage-operator/crds/`
+4. Apply the CRDs in your local cluster: `kubectl apply -f helm/hybrid-cloud-object-storage-operator-crds/templates/`
 5. If you want to deploy to azure: Either have the azure cli installed and configured with an active login or export the following environment variables: `AZURE_TENANT_ID`, `AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET`
 6. Adapt the `config.yaml` to suit your needs
 7. Run `kopf run main.py -A`

--- a/README.md
+++ b/README.md
@@ -103,7 +103,6 @@ backends:  # Configuration for the different backends. Required fields are only 
         - vnet: foobar-vnet  # Name of the virtual network, required
           subnet: default  # Name of the subnet, required
     backup: # Configuration for use of Azure Backup Services
-      enabled: false  # If enabled, the storage account will be added to an existing backup vault. Backup instances will not be cleaned up with Object Storage Buckets for recovery purposes
       vault_name: foobar-vault  # The name of the existing backup vault, make sure the Storage Account has the Role Assignment "Storage Account Backup Contributor" for the according vault
       policy_id: 123123123  # The policy within the backup vault to use
     parameters:  # Fields here define defaults for parameters also in the CRD and are used if the parameter is not set in the custom object supplied by the user
@@ -119,6 +118,9 @@ backends:  # Configuration for the different backends. Required fields are only 
         days: 2  # Number of days to keep deleted data, optional
       sftp:  # SFTP feature can only be enabled for the first time at creation of the storage account. Background: The hierarchical namespace setting is needed for SFTP and will be used implicitly but it can be only set at creation time.
         enabled: false  # enable SFTP interface, optional
+      backup:
+        enabled: false  # If enabled, the storage accounts will be added to an existing backup vault by default. Backup instances will not be cleaned up with Object Storage Buckets for recovery purposes
+
 ```
 
 Single configuration options can also be provided via environment variables, the complete path is concatenated using underscores, written in uppercase and prefixed with `HYBRIDCLOUD_`. As an example: `backends.azureblob.subscription_id` becomes `HYBRIDCLOUD_BACKENDS_AZUREBLOB_SUBSCRIPTION_ID`.
@@ -186,6 +188,8 @@ spec:
     deleteRetention:  # Settings related to delete retention, optional
       enabled: false  # Enable retention on delete, optional
       retentionPeriodInDays: 1  # Days to keep deleted data, optional
+  backup:
+    enabled: false  # Override the default backup strategy configured in the global operator config
   containers:  # Only relevant for azure, list of containers to create in the bucket, for azure at least one is required, containers not on the list will be removed from the storage account, including their data
     - name: assets  # Name of the container, required
       anonymousAccess: false  # If set to true objects in the container can be accessed without authentication/authorization, only relevant if `security.anonymousAccess` is set to true, optional

--- a/helm/hybrid-cloud-object-storage-operator-crds/templates/objectstorage.yaml
+++ b/helm/hybrid-cloud-object-storage-operator-crds/templates/objectstorage.yaml
@@ -97,6 +97,11 @@ spec:
                           type: boolean
                         retentionPeriodInDays:
                           type: number
+                backup:
+                  type: object
+                  properties:
+                    enabled:
+                      type: boolean
                 containers:
                   type: array
                   items:

--- a/hybridcloud/backends/azureblob.py
+++ b/hybridcloud/backends/azureblob.py
@@ -131,7 +131,6 @@ class AzureBlobBackend:
                 is_local_user_enabled=sftp_enabled
             )
             self._storage_client.storage_accounts.begin_create(self._resource_group, bucket_name, parameters=parameters).result()
-            storage_account = self._storage_client.storage_accounts.get_properties(self._resource_group, bucket_name)
         else:
             # Update storage account
             parameters = StorageAccountUpdateParameters(
@@ -143,6 +142,8 @@ class AzureBlobBackend:
                 is_local_user_enabled=sftp_enabled
             )
             self._storage_client.storage_accounts.update(self._resource_group, bucket_name, parameters=parameters)
+
+        storage_account = self._storage_client.storage_accounts.get_properties(self._resource_group, bucket_name)
 
         if _backend_config("lock_from_deletion", default=False):
             self._lock_client.management_locks.create_or_update_at_resource_level(self._resource_group, "Microsoft.Storage", "", "storageAccounts", bucket_name, "DoNotDeleteLock", parameters=ManagementLockObject(level="CanNotDelete", notes="Protection from accidental deletion"))

--- a/hybridcloud/config.py
+++ b/hybridcloud/config.py
@@ -9,7 +9,7 @@ _config = None
 
 class ConfigurationException(Exception):
     def __init__(self, description):
-        super().__init(description)
+        super().__init__(description)
 
 
 def _get_config_value_from_env(key):

--- a/hybridcloud/handlers/bucket.py
+++ b/hybridcloud/handlers/bucket.py
@@ -4,6 +4,7 @@ from ..config import config_get
 from ..util.reconcile_helpers import ignore_control_label_change, process_action_label
 from ..util import k8s
 from ..util.constants import BACKOFF
+from ..util.exceptions import BackupEnabledException
 
 
 if config_get("handler_on_resume", default=False):
@@ -59,7 +60,11 @@ def bucket_delete(spec, status, name, namespace, logger, **kwargs):
     backend = bucket_backend(backend_name, logger)
     if backend.bucket_exists(namespace, name):
         logger.info("Deleting bucket")
-        backend.delete_bucket(namespace, name)
+        try:
+            backend.delete_bucket(namespace, name)
+        except BackupEnabledException as e:
+            raise kopf.TemporaryError(str(e))
+            
     else:
         logger.info("Bucket does not exist. Not doing anything")
     k8s.delete_secret(namespace, spec["credentialsSecret"])

--- a/hybridcloud/handlers/bucket.py
+++ b/hybridcloud/handlers/bucket.py
@@ -4,7 +4,7 @@ from ..config import config_get
 from ..util.reconcile_helpers import ignore_control_label_change, process_action_label
 from ..util import k8s
 from ..util.constants import BACKOFF
-from ..util.exceptions import BackupEnabledException
+from ..util.exceptions import DeletionWithBackupEnabledException
 
 
 if config_get("handler_on_resume", default=False):
@@ -62,8 +62,10 @@ def bucket_delete(spec, status, name, namespace, logger, **kwargs):
         logger.info("Deleting bucket")
         try:
             backend.delete_bucket(namespace, name)
-        except BackupEnabledException as e:
-            raise kopf.TemporaryError(str(e))
+        except DeletionWithBackupEnabledException as e:
+            reason = str(e)
+            _status(name, namespace, status, "failed", f"Deletion failed: {reason}")
+            raise kopf.TemporaryError(reason)
             
     else:
         logger.info("Bucket does not exist. Not doing anything")

--- a/hybridcloud/util/azure.py
+++ b/hybridcloud/util/azure.py
@@ -1,6 +1,7 @@
 from azure.identity import DefaultAzureCredential
 from azure.mgmt.storage import StorageManagementClient
 from azure.mgmt.resource import ManagementLockClient
+from azure.mgmt.dataprotection import DataProtectionClient
 from ..config import get_one_of
 
 
@@ -18,3 +19,7 @@ def azure_client_storage():
 
 def azure_client_locks():
     return ManagementLockClient(_credentials(), _subscription_id())
+
+
+def azure_backup_client():
+    return DataProtectionClient(_credentials(), _subscription_id())

--- a/hybridcloud/util/exceptions.py
+++ b/hybridcloud/util/exceptions.py
@@ -1,0 +1,2 @@
+class BackupEnabledException(Exception):
+    pass

--- a/hybridcloud/util/exceptions.py
+++ b/hybridcloud/util/exceptions.py
@@ -1,2 +1,2 @@
-class BackupEnabledException(Exception):
+class DeletionWithBackupEnabledException(Exception):
     pass

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,5 @@ kopf==1.35.2
 azure-identity==1.7.1
 azure-mgmt-resource==20.0.0
 azure-mgmt-storage==19.1.0
+azure-mgmt-dataprotection==1.0.0b2
 pyyaml==6.0


### PR DESCRIPTION
This PR introduces the option to enable cloud provider specific backup solutions. Since Azure is the only supported Cloud Platform so far, the implementation uses Azure Backup Vault for this.

Note: is seems like there is a bug either in the azure-mgmt-dataprotection library or the Azure API itself. Sometimes when applying the custom resource without backup enabled, and then enabling it + reapply, this exception is thrown:

```json
{
    "message": "Input provided for the call is invalid",
    "recommendedAction": [
        "Please check the required inputs"
    ],
    "details": null,
    "code": "BMSUserErrorInvalidInput",
    "target": "",
    "innerError": null,
    "isRetryable": false,
    "isUserError": false,
    "properties": {
        "ActivityId": "28075f98-7ace-11ed-b76a-f6cd300a3799"
    }
}
```

After 2-3 reconciles, this problem solves itself, but many times, it doesnt even happen. I have not yet been able to figure out why that is. This bug is also mentioned [here](https://github.com/hashicorp/terraform-provider-azurerm/issues/18577) which leads me to the conclusion that this implementation is fine and the problem lies without the bounds of this operator.