### PR TITLE
Calling bucket_spec_valid in a k8s validating webhook

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ The operator is implemented in Python using the [Kopf](https://github.com/nolar/
 To run it locally follow these steps:
 
 1. Create and activate a local python virtualenv
-2. Install dependencies: `pip install -r requirements.txt`. During development the additional command `pip install 'kopf[dev]'` is required (but not for production, so it is not part of requirements.txt).
+2. Install dependencies: `pip install -r requirements.txt`
 3. Setup a local kubernetes cluster, e.g. with k3d: `k3d cluster create`
 4. Apply the CRDs in your local cluster: `kubectl apply -f helm/hybrid-cloud-object-storage-operator-crds/templates/`
 5. If you want to deploy to azure: Either have the azure cli installed and configured with an active login or export the following environment variables: `AZURE_TENANT_ID`, `AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET`

--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ The operator is implemented in Python using the [Kopf](https://github.com/nolar/
 To run it locally follow these steps:
 
 1. Create and activate a local python virtualenv
-2. Install dependencies: `pip install -r requirements.txt`
+2. Install dependencies: `pip install -r requirements.txt`. During development the additional command `pip install 'kopf[dev]'` is required (but not for production, so it is not part of requirements.txt).
 3. Setup a local kubernetes cluster, e.g. with k3d: `k3d cluster create`
 4. Apply the CRDs in your local cluster: `kubectl apply -f helm/hybrid-cloud-object-storage-operator-crds/templates/`
 5. If you want to deploy to azure: Either have the azure cli installed and configured with an active login or export the following environment variables: `AZURE_TENANT_ID`, `AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET`

--- a/hybridcloud/operator.py
+++ b/hybridcloud/operator.py
@@ -34,10 +34,9 @@ def configure(settings: kopf.OperatorSettings, **_):
     settings.watching.connect_timeout = 60
     settings.watching.client_timeout = 120
     settings.networking.request_timeout = 120
-    settings.admission.managed = 'auto.kopf.dev'
+    settings.admission.managed = 'hybridcloud.maibornwolff.de'
 
-    if os.environ.get('ENVIRONMENT') is None:
-        settings.admission.server = kopf.WebhookK3dServer(port=54321)
+    settings.admission.server = kopf.WebhookAutoServer()
 
 
 # Check config to abort early in case of problem

--- a/hybridcloud/operator.py
+++ b/hybridcloud/operator.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+import os
 import random
 import kopf
 from . import config
@@ -33,6 +34,10 @@ def configure(settings: kopf.OperatorSettings, **_):
     settings.watching.connect_timeout = 60
     settings.watching.client_timeout = 120
     settings.networking.request_timeout = 120
+    settings.admission.managed = 'auto.kopf.dev'
+
+    if os.environ.get('ENVIRONMENT') is None:
+        settings.admission.server = kopf.WebhookK3dServer(port=54321)
 
 
 # Check config to abort early in case of problem

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 kubernetes==25.3.0
-kopf==1.36.0
+kopf[dev]==1.36.0
 azure-identity==1.12.0
 azure-mgmt-resource==22.0.0
 azure-mgmt-storage==21.0.0


### PR DESCRIPTION
This PR leverages the K8s native [dynamic admission controllers](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/) to run the function `bucket_spec_valid` in a validating webhook. This causes invalid specs to actually fail whereas until now invalid specs would only cause an error in the status.

In this example, the spec was invalid due to a name that was longer than 24 characters. The screenshot shows that the info generated by the `bucket_spec_valid` method is passed along to the user in the the form of a [kopf.AdmissionError](https://kopf.readthedocs.io/en/stable/admission/#validation-handlers)

<img width="1036" alt="image" src="https://user-images.githubusercontent.com/25712873/209847038-3202a833-cf95-4906-a50e-5b590813cfb9.png">


Once this PR is approved, I will do the same thing for the other `hybrid-cloud`-operators
