### PR TITLE
Adds support for lifecycle rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,8 +194,8 @@ spec:
     enabled: false  # Override the default backup strategy configured in the global operator config
   lifecycle:  # Define rules which determine the lifecycle of blob resources
     rules:
-      - blobPrefix: foobar
-        deleteDaysAfterModification: 30
+      - blobPrefix: foobar  # Prefix of blob resources to apply rule to, required
+        deleteDaysAfterModification: 30  # Delete blob resources after number of days after last modification, required
   containers:  # Only relevant for azure, list of containers to create in the bucket, for azure at least one is required, containers not on the list will be removed from the storage account, including their data
     - name: assets  # Name of the container, required
       anonymousAccess: false  # If set to true objects in the container can be accessed without authentication/authorization, only relevant if `security.anonymousAccess` is set to true, optional

--- a/README.md
+++ b/README.md
@@ -192,6 +192,10 @@ spec:
       retentionPeriodInDays: 1  # Days to keep deleted data, optional
   backup:
     enabled: false  # Override the default backup strategy configured in the global operator config
+  lifecycle:  # Define rules which determine the lifecycle of blob resources
+    rules:
+      - blobPrefix: foobar
+        deleteDaysAfterModification: 30
   containers:  # Only relevant for azure, list of containers to create in the bucket, for azure at least one is required, containers not on the list will be removed from the storage account, including their data
     - name: assets  # Name of the container, required
       anonymousAccess: false  # If set to true objects in the container can be accessed without authentication/authorization, only relevant if `security.anonymousAccess` is set to true, optional

--- a/helm/hybrid-cloud-object-storage-operator-crds/templates/objectstorage.yaml
+++ b/helm/hybrid-cloud-object-storage-operator-crds/templates/objectstorage.yaml
@@ -102,6 +102,21 @@ spec:
                   properties:
                     enabled:
                       type: boolean
+                lifecycle:
+                  type: object
+                  properties:
+                    rules:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          blobPrefix:
+                            type: string
+                          deleteDaysAfterModification:
+                            type: number
+                        required:
+                          - blobPrefix
+                          - deleteDaysAfterModification
                 containers:
                   type: array
                   items:

--- a/hybridcloud/backends/azureblob.py
+++ b/hybridcloud/backends/azureblob.py
@@ -4,7 +4,9 @@ from azure.mgmt.storage.models import StorageAccountCreateParameters, StorageAcc
     BlobServiceProperties, \
     CorsRules, CorsRule, NetworkRuleSet, IPRule, VirtualNetworkRule, BlobContainer, \
     StorageAccountCheckNameAvailabilityParameters, StorageAccountRegenerateKeyParameters, \
-    DeleteRetentionPolicy, RestorePolicyProperties, ChangeFeed, LocalUser, PermissionScope, SshPublicKey
+    DeleteRetentionPolicy, RestorePolicyProperties, ChangeFeed, LocalUser, PermissionScope, SshPublicKey, \
+    ManagementPolicy, ManagementPolicySchema, ManagementPolicyRule, RuleType, ManagementPolicyDefinition, \
+    ManagementPolicyAction, ManagementPolicyFilter, ManagementPolicyBaseBlob, DateAfterModification
 from azure.mgmt.resource.locks.models import ManagementLockObject
 from azure.mgmt.dataprotection.models import BackupInstanceResource, BackupInstance, PolicyInfo, Datasource
 from ..util.azure import azure_client_storage, azure_client_locks, azure_backup_client
@@ -204,9 +206,9 @@ class AzureBlobBackend:
                 if existing_username not in users_from_spec:
                     self._storage_client.local_users.delete(self._resource_group, bucket_name, existing_username)
 
-        if backup_enabled:
-            storage_account = self._storage_client.storage_accounts.get_properties(self._resource_group, bucket_name)
+        storage_account = self._storage_client.storage_accounts.get_properties(self._resource_group, bucket_name)
 
+        if backup_enabled:
             vault_name = _backend_config("backup.vault_name", fail_if_missing=True)
             policy_name = _backend_config("backup.policy_name", fail_if_missing=True)
 
@@ -235,6 +237,15 @@ class AzureBlobBackend:
                 parameters=backup_properties
             ).result()
 
+        lifecycle_policy = self._map_lifecycle_policy(spec)
+        if lifecycle_policy is not None:
+            self._storage_client.management_policies.create_or_update(
+                resource_group_name=self._resource_group,
+                account_name=storage_account.name,
+                management_policy_name="default",
+                properties=lifecycle_policy
+            )
+
         # Credentials
         for key in self._storage_client.storage_accounts.list_keys(self._resource_group, bucket_name).keys:
             if key.key_name == "key1":
@@ -245,7 +256,6 @@ class AzureBlobBackend:
                     "connection_string": f"DefaultEndpointsProtocol=https;AccountName={bucket_name};AccountKey={key.value};EndpointSuffix=core.windows.net",
                 }
         raise Exception("Could not find keys in azure")
-
 
     def delete_bucket(self, namespace, name):
         bucket_name = _calc_name(namespace, name)
@@ -295,6 +305,26 @@ class AzureBlobBackend:
             ip_rules=ip_rules,
             default_action="Allow" if public_access else "Deny"
         )
+
+    def _map_lifecycle_policy(self, spec):
+        lifecycle_rules = []
+        spec_lifecycle_rules = field_from_spec(spec, "lifecycle.rules", [])
+        if len(spec_lifecycle_rules) == 0:
+            return None
+        for index, rule in enumerate(spec_lifecycle_rules):
+            lifecycle_rules.append(ManagementPolicyRule(name=f"rule-{index}",
+                                                        type=RuleType.LIFECYCLE,
+                                                        definition=ManagementPolicyDefinition(
+                                                            actions=ManagementPolicyAction(
+                                                                base_blob=ManagementPolicyBaseBlob(
+                                                                    delete=DateAfterModification(
+                                                                        days_after_modification_greater_than=rule[
+                                                                            "deleteDaysAfterModification"]))),
+                                                            filters=ManagementPolicyFilter(
+                                                                blob_types=["blockBlob"],
+                                                                prefix_match=[rule["blobPrefix"]])),
+                                                        enabled=True))
+        return ManagementPolicy(policy=ManagementPolicySchema(rules=lifecycle_rules))
 
     def _get_backup_lock(self, bucket_name):
         try:


### PR DESCRIPTION
We propse support for lifecycle rules.

Lifecycle rules (aka: lifecycle policies) allow to define the lifecycle of blob resources, e.g. deleting blob resources (1) matching a specific path prefix (2) after a specific number of days after their last modification.
Lifecycle rules are a generic concept and supported by several cloud providers, such as Azure and AWS.

We provide an extension of the CRD as well as an implementation for Azure. So far, we support the properties _blobPrefix_ and _deleteDaysAfterModification_.