### PR TITLE
Adds attributes DataSource.object_type, DataSource.resource_uri and friendly_name to BackupInstance

### DIFF
--- a/hybridcloud/backends/azureblob.py
+++ b/hybridcloud/backends/azureblob.py
@@ -228,38 +228,31 @@ class AzureBlobBackend:
 
             policy_id = f"/subscriptions/{self._subscription_id}/resourceGroups/{self._resource_group}/providers/Microsoft.DataProtection/backupVaults/{vault_name}/backupPolicies/{policy_name}"
 
-            self._logger.info("vault_name: %s", vault_name)
-            self._logger.info("policy_name: %s", policy_name)
-            self._logger.info("policy_id: %s", policy_id)
-            self._logger.info("storage_account.id: %s", storage_account.id)
-            self._logger.info("storage_account.name: %s", storage_account.name)
-            self._logger.info("self._location: %s", self._location)
-            self._logger.info("self._resource_group: %s", self._resource_group)
-            self._logger.info("bucket_name: %s", bucket_name)
+            backup_properties = BackupInstanceResource(
+                properties=BackupInstance(
+                    data_source_info=Datasource(
+                        datasource_type="Microsoft.Storage/storageAccounts/blobServices",
+                        object_type="Datasource",
+                        resource_id=storage_account.id,
+                        resource_location=self._location,
+                        resource_name=storage_account.name,
+                        resource_type="Microsoft.Storage/storageAccounts",
+                        resource_uri=""
+                    ),
+                    friendly_name=bucket_name,
+                    object_type="BackupInstance",
+                    policy_info=PolicyInfo(
+                        policy_id=policy_id
+                    )
+                )
+            )
 
             self._backup_client.backup_instances.begin_create_or_update(
                 resource_group_name=self._resource_group,
                 vault_name=vault_name,
                 backup_instance_name=bucket_name,
-                content_type="application/json",
-                parameters={
-                    "properties": {
-                        "dataSourceInfo": {
-                            "datasourceType": "Microsoft.Storage/storageAccounts/blobServices",
-                            "objectType": "Datasource",
-                            "resourceID": storage_account.id,
-                            "resourceLocation": self._location,
-                            "resourceName": storage_account.name,
-                            "resourceType": "Microsoft.Storage/storageAccounts",
-                            "resourceUri": ""
-                        },
-                        "friendlyName": bucket_name,
-                        "objectType": "BackupInstance",
-                        "policyInfo": {
-                            "policyId": policy_id
-                        }
-                    }
-                }).result()
+                parameters=backup_properties
+            ).result()
 
         lifecycle_policy = self._map_lifecycle_policy(spec)
         if lifecycle_policy is not None:


### PR DESCRIPTION
After several rounds of intense debugging, we've found that the Azure API is assumed to "somehow" require the attributes  DataSource.object_type, DataSource.resource_uri and friendly_name for the resource BackupInstance.

Without setting these attributes, we get the following error when creating/updating a BackupInstance instance.
`azure.core.exceptions.HttpResponseError: (BMSUserErrorInvalidInput) Input provided for the call is invalid
Code: BMSUserErrorInvalidInput
Message: Input provided for the call is invalid
Additional Information:Type: UserFacingError
Info: {
    "message": "Input provided for the call is invalid",
    "recommendedAction": [
        "Please check the required inputs"
    ],
    "details": null,
    "code": "BMSUserErrorInvalidInput",
    "target": "",
    "innerError": null,
    "isRetryable": false,
    "isUserError": false,
    "properties": {
        "ActivityId": "<redacted>"
    }
}`

Please squash our commits, since we've needed a lot of tries. ;)
Thanks!