### PR TITLE
Add classes to configure backup policies on a storage account level

### DIFF
--- a/helm/hybrid-cloud-object-storage-operator-crds/templates/objectstorage.yaml
+++ b/helm/hybrid-cloud-object-storage-operator-crds/templates/objectstorage.yaml
@@ -102,6 +102,8 @@ spec:
                   properties:
                     enabled:
                       type: boolean
+                    class:
+                      type: string
                 size:
                   type: object
                   properties:


### PR DESCRIPTION
This PR adds the possibility to change the backup policy for each object-storage individually. Similar to setting the accessibility of object-storages